### PR TITLE
fix: migrate project endpoint to v4

### DIFF
--- a/src/funcs/favorites.ts
+++ b/src/funcs/favorites.ts
@@ -2,13 +2,14 @@ import { ClockodoProp } from "../types/clockodo";
 import actionSelect from "inquirer-action-select";
 import { confirm, input } from "@inquirer/prompts";
 import { getEntryData } from "./manual";
+import { getAllProjects } from "../utils/projects";
 import chalk from "chalk";
 
 export const favorites = async ({ clockodo }: ClockodoProp) => {
   const response = await clockodo.api.get("v2/favorites");
   const favorites = response.data;
   const { customers } = await clockodo.getCustomers();
-  const { projects } = await clockodo.getProjects();
+  const projects = await getAllProjects({ clockodo });
   const { services } = await clockodo.getServices();
 
   const mappedFavorites = favorites.reduce(

--- a/src/funcs/jira.ts
+++ b/src/funcs/jira.ts
@@ -8,6 +8,7 @@ import {
   getDevelopmentServiceId,
   getTestingServiceId,
 } from "../utils/defaults";
+import { createProject, getAllProjects } from "../utils/projects";
 import chalk from "chalk";
 
 enum Mode {
@@ -124,26 +125,25 @@ const getOrCreateProject = async ({
 }: ClockodoProp & { project?: string; customersId: number; autoCreate?: boolean }) => {
   let projectsId: number | undefined;
   if (project) {
-    const { projects } = await clockodo.getProjects();
+    const projects = await getAllProjects({ clockodo });
     projectsId = projects?.find(({ name }) => name === project)?.id;
 
     if (!projectsId) {
-      const { createProject } = autoCreate 
-        ? { createProject: true }
+      const { shouldCreate } = autoCreate
+        ? { shouldCreate: true }
         : await inquirer.prompt([
             {
               type: "confirm",
-              name: "createProject",
+              name: "shouldCreate",
               message: `Project ${chalk.yellow(
                 project
               )} does not exist. Do you want to create it?`,
             },
           ]);
 
-      if (createProject) {
-        const {
-          project: { id },
-        } = await clockodo.addProject({
+      if (shouldCreate) {
+        const { id } = await createProject({
+          clockodo,
           name: project,
           customersId,
         });

--- a/src/funcs/manual.ts
+++ b/src/funcs/manual.ts
@@ -3,6 +3,7 @@ import { ClockodoProp } from "../types/clockodo";
 import { Separator } from "@inquirer/prompts";
 import ora from "ora";
 import { ClockEditReturnType, Entry, TimeEntry } from "clockodo";
+import { getAllProjects } from "../utils/projects";
 import chalk from "chalk";
 
 enum Mode {
@@ -57,7 +58,8 @@ export const getEntryData = async ({ clockodo }: ClockodoProp) => {
     },
   ]);
 
-  const { projects } = await clockodo.getProjects({
+  const projects = await getAllProjects({
+    clockodo,
     filterCustomersId: customersId,
     filterActive: true,
   });

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -1,0 +1,85 @@
+import { ClockodoProp } from "../types/clockodo";
+
+/**
+ * The SDK's `getProjects`/`addProject` helpers still target the legacy
+ * `/v2/projects` endpoint, which has been decommissioned. We therefore talk to
+ * the `/v4/projects` endpoint directly via `clockodo.api`, which transparently
+ * maps our camelCase params/responses to and from the API's snake_case.
+ */
+
+export type Project = {
+  id: number;
+  customersId: number;
+  name: string;
+  number: string | null;
+  active: boolean;
+  billableDefault: boolean;
+  note?: string | null;
+  completed: boolean;
+  completedAt: string | null;
+};
+
+type Paging = {
+  itemsPerPage: number;
+  currentPage: number;
+  countPages: number;
+  countItems: number;
+};
+
+type ProjectsResponse = {
+  paging: Paging;
+  data: Project[];
+};
+
+type ProjectResponse = {
+  data: Project;
+};
+
+type GetProjectsFilters = {
+  filterCustomersId?: number;
+  filterActive?: boolean;
+  filterCompleted?: boolean;
+  filterFulltext?: string;
+};
+
+// The maximum the v4 endpoint allows, so we usually fetch everything in one go.
+const ITEMS_PER_PAGE = 5000;
+
+/**
+ * Fetches every project across all pages, matching the behaviour the SDK's
+ * `getProjects` used to provide.
+ */
+export const getAllProjects = async ({
+  clockodo,
+  ...filters
+}: ClockodoProp & GetProjectsFilters): Promise<Project[]> => {
+  const projects: Project[] = [];
+  let page = 1;
+  let countPages = 1;
+
+  do {
+    const { data, paging } = await clockodo.api.get<ProjectsResponse>(
+      "v4/projects",
+      { ...filters, page, itemsPerPage: ITEMS_PER_PAGE }
+    );
+
+    projects.push(...data);
+    countPages = paging.countPages;
+    page += 1;
+  } while (page <= countPages);
+
+  return projects;
+};
+
+export const createProject = async ({
+  clockodo,
+  name,
+  customersId,
+}: ClockodoProp & { name: string; customersId: number }): Promise<Project> => {
+  const { data } = await clockodo.api.post<ProjectResponse>("v4/projects", {
+    name,
+    customersId,
+  });
+
+  return data;
+};


### PR DESCRIPTION
The Clockodo SDK still routes getProjects/addProject through the decommissioned /v2/projects endpoint. Add getAllProjects and createProject helpers that talk to /v4/projects directly via clockodo.api, paginating to fetch every project, and use them across the jira, manual and favorites flows.